### PR TITLE
removed navbar dropdown for events and linked it to coming soon page

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,10 @@
             <li class="nav-item">
               <a class="nav-link" href="index.html#home">Home<span></span></a>
             </li>
-            <li class="nav-item dropdown">
+             <li class="nav-item">
+              <a class="nav-link" href="/coming-soon.html">Events<span></span></a>
+            </li>
+            <!-- <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="editionsDropdown" role="button" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false">Events 3.0</a>
               <div class="dropdown-menu navigation__submenu" aria-labelledby="editionsDropdown">
@@ -368,7 +371,7 @@
                 <a class="dropdown-item" href="/events/2024/event-2024.html">ACN Cyber Tech Fest</a>
                 <a class="dropdown-item" href="/Editions/cyber-awareness-page/index.html">ACN Cyber Awareness</a>
               </div>
-            </li>
+            </li> -->
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="editionsDropdown" role="button" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false">Editions</a>


### PR DESCRIPTION
Previous:
<img width="475" height="256" alt="image" src="https://github.com/user-attachments/assets/63d1d60a-5d15-41ed-86e7-924a1436a95e" />


Now:
<img width="732" height="112" alt="image" src="https://github.com/user-attachments/assets/1738e242-b27e-4980-88e6-95e300802069" />
The Event button will redirect to coming soon page